### PR TITLE
Support filtering resources by label

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,12 +14,16 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&configurationFile, "config", "config/config.json", "Path to configuration file.")
 	rootCmd.PersistentFlags().StringVar(&namespace, "namespace", "default", "Namespace of resources.")
 	rootCmd.PersistentFlags().StringVar(&outputFile, "output", "assets/output.dot", "Path to output file.")
+	rootCmd.PersistentFlags().StringVar(&labelSelector, "label-selector", "", "Filter resources by label. Comma separated key-value pairs.")
 }
 
 // CLI Flags
-var configurationFile string
-var outputFile string
-var namespace string
+var (
+	configurationFile string
+	outputFile        string
+	namespace         string
+	labelSelector     string
+)
 
 var rootCmd = &cobra.Command{
 	Use:           "kube-visualization",

--- a/cmd/visualize.go
+++ b/cmd/visualize.go
@@ -24,7 +24,7 @@ var visualizeCmd = &cobra.Command{
 			panic(err)
 		}
 
-		client, err := client.NewClient()
+		client, err := client.NewClient(client.WithLabelSelector(labelSelector))
 		if err != nil {
 			panic(fmt.Errorf("failed to create new client: %v", err))
 		}


### PR DESCRIPTION
This PR:
- Allow the listed resources to be filtered by label.
- New CLI flag "label-selector" added. Value for this is a comma separated string of key value pairs e.g "key1=val1,key2=val2".
- Add configuration options for the client. Only one currently which is the label selector. This is then used for the metav1.ListOptions when listing the resources.