### PR TITLE
feat(Makefile): Add docker-run target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github/
+assets/output.*
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,16 @@ COPY pkg/ pkg/
 RUN --mount=type=cache,target="/root/.kube-visualization-cache" CGO_ENABLED=0 \
     GOOS=linux GOARCH=amd64 go build -o kube-visualization
 
+COPY assets/ assets/
+COPY config/ config/
+
 # Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/kube-visualization .
+COPY --from=builder /workspace/assets/ assets/
+COPY --from=builder /workspace/config/ config/
 USER 65532:65532
 
 ENTRYPOINT ["/kube-visualization"]

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,15 @@ run:
 generate: ## Render the output dot file.
 	dot -T$(FORMAT):cairo assets/output.dot > assets/output.$(FORMAT)
 
+.PHONY: docker-run
+docker-run:
+	docker run --network host \
+	--user $(shell id -u):$(shell id -g) \
+	-v $(shell pwd)/assets:/assets \
+	-v $(shell pwd)/config:/config:ro \
+	-v ~/.kube/config:/.kube/config \
+	$(IMG) $(CMD) $(FLAGS) 
+
 ##@ Build
 clean:
 	go clean -modcache


### PR DESCRIPTION
This PR:
- Add a "docker-run" make target to the Makefile.
- Local assets, config and kube config are volumed in.
- The assets and configs should be burned into the image as part of the build step to ensure default configuration is present.