### PR TITLE
fix: Checkout full history in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # fetch full history
+        filter: tree:0
 
     - name: Build docker image
       run: |


### PR DESCRIPTION
This PR:
- Checkout full history in build workflow so that tags can be described.