### PR TITLE
build: Push docker image in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,11 +6,15 @@ on:
   #   branches:
   #     - main
 
+env:
+  IMAGE_REGISTRY: ghcr.io
+
 jobs:
   build:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      packages: write
 
     steps:
     - name: Checkout repository
@@ -18,7 +22,18 @@ jobs:
       with:
         fetch-depth: 0 # fetch full history
         filter: tree:0
+    
+    - name: Log in to the Container registry
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build docker image
       run: |
         make docker-build 
+
+    - name: Push docker image
+      run: |
+        make docker-push 


### PR DESCRIPTION
This PR:
- Push docker image as part of build workflow.